### PR TITLE
Fix redis key sanitization bug

### DIFF
--- a/src/__tests__/services/redis.test.ts
+++ b/src/__tests__/services/redis.test.ts
@@ -90,8 +90,8 @@ describe('Redis Service', () => {
             expect(sanitizeKey).toHaveBeenCalledWith(mockKey);
 
           // Check that Redis.get and ttl were called with the correct key
-            expect(mockRedisGet).toHaveBeenCalledWith(mockKey);
-          expect(mockRedisTtl).toHaveBeenCalledWith(mockKey);
+            expect(mockRedisGet).toHaveBeenCalledWith(mockSanitizedKey);
+          expect(mockRedisTtl).toHaveBeenCalledWith(mockSanitizedKey);
 
           // Check that the result includes the expiry time
           expect(result).toEqual(mockPhotoFlickr.map(photo => ({
@@ -115,8 +115,8 @@ describe('Redis Service', () => {
             expect(sanitizeKey).toHaveBeenCalledWith(mockKey);
 
           // Check that Redis.get and ttl were called with the correct key
-            expect(mockRedisGet).toHaveBeenCalledWith(mockKey);
-          expect(mockRedisTtl).toHaveBeenCalledWith(mockKey);
+            expect(mockRedisGet).toHaveBeenCalledWith(mockSanitizedKey);
+          expect(mockRedisTtl).toHaveBeenCalledWith(mockSanitizedKey);
 
             expect(result).toBeNull();
         });
@@ -136,8 +136,8 @@ describe('Redis Service', () => {
             expect(sanitizeKey).toHaveBeenCalledWith(mockKey);
 
           // Check that Redis.get and ttl were called with the correct key
-            expect(mockRedisGet).toHaveBeenCalledWith(mockKey);
-          expect(mockRedisTtl).toHaveBeenCalledWith(mockKey);
+            expect(mockRedisGet).toHaveBeenCalledWith(mockSanitizedKey);
+          expect(mockRedisTtl).toHaveBeenCalledWith(mockSanitizedKey);
         });
     });
 
@@ -157,7 +157,7 @@ describe('Redis Service', () => {
 
             // Check that Redis.set was called with the correct parameters
             expect(mockRedisSet).toHaveBeenCalledWith(
-                mockKey,
+                mockSanitizedKey,
                 JSON.stringify(mockPhotoFlickr),
                 {ex: 3600}
             );
@@ -178,7 +178,7 @@ describe('Redis Service', () => {
 
             // Check that Redis.set was called with the correct parameters
             expect(mockRedisSet).toHaveBeenCalledWith(
-                mockKey,
+                mockSanitizedKey,
                 JSON.stringify(mockPhotoFlickr),
                 {ex: 3600}
             );

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -13,8 +13,8 @@ export async function getCachedData(
   const redis = Redis.fromEnv();
   const sanitizedKey = sanitizeKey(key);
   console.log(chalk.cyan(`- Getting Redis Cache for (${sanitizedKey}):`));
-  const expiryDate = await redis.ttl(key);
-  const data = await redis.get<Array<PhotoFlickr>>(key);
+  const expiryDate = await redis.ttl(sanitizedKey);
+  const data = await redis.get<Array<PhotoFlickr>>(sanitizedKey);
 
   if (data === null) {
     console.warn(chalk.red("- Redis Cache miss"));
@@ -35,7 +35,7 @@ export async function setCachedData(
 ): Promise<void> {
   const redis = Redis.fromEnv();
   const sanitizedKey = sanitizeKey(key);
-  const result = await redis.set(key, JSON.stringify(data), {ex: expiryInSeconds});
+  const result = await redis.set(sanitizedKey, JSON.stringify(data), {ex: expiryInSeconds});
   console.log(`- Redis Cache Write Success (${sanitizedKey}):`);
   console.log(chalk.cyan("- Redis Cache response"), result);
   return;


### PR DESCRIPTION
## Summary
- sanitize redis keys before get/set/ttl operations
- update tests for redis service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512a2ed388832eb8d40168e43fff5a