### PR TITLE
⚡ Bolt: Optimize LocaleSwitcher items array allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -98,3 +98,7 @@
 ## 2026-03-24 - [Performance: I/O Operation Concurrency in Batch Processing]
 **Learning:** Using `Promise.all` directly with large arrays to perform I/O-bound operations (like generating signed URLs or mapping files) causes all operations to start concurrently. This can lead to resource exhaustion, memory issues, or hitting API rate limits.
 **Action:** Replace unbounded `Promise.all` with a concurrency-controlled utility like `concurrentMap` (using a worker pattern) to limit the number of simultaneous asynchronous tasks.
+
+## 2026-04-25 - [Performance: React Component Re-renders]
+**Learning:** Passing a newly created inline array or object as a prop (e.g., `items={[...]}`) forces the child component to re-render every time the parent renders, as the reference changes.
+**Action:** In React components, prevent unnecessary re-renders of child components by memoizing inline array or object props (e.g., using `useMemo` for static items like a language list passed to a Select component).

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,39 +1,46 @@
 import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
 import LocaleSwitcherSelect from "./LocaleSwitcherSelect";
 
 export default function LocaleSwitcher() {
   const t = useTranslations("LocaleSwitcher");
   const locale = useLocale();
 
+  // ⚡ Bolt: Memoize items array to prevent unnecessary re-renders of LocaleSwitcherSelect
+  const items = useMemo(
+    () => [
+      {
+        value: "en",
+        label: t("en"),
+      },
+      {
+        value: "es",
+        label: t("es"),
+      },
+      {
+        value: "fr",
+        label: t("fr"),
+      },
+      {
+        value: "ca",
+        label: t("ca"),
+      },
+      {
+        value: "it",
+        label: t("it"),
+      },
+      {
+        value: "uk",
+        label: t("uk"),
+      },
+    ],
+    [t],
+  );
+
   return (
     <LocaleSwitcherSelect
       defaultValue={locale}
-      items={[
-        {
-          value: "en",
-          label: t("en"),
-        },
-        {
-          value: "es",
-          label: t("es"),
-        },
-        {
-          value: "fr",
-          label: t("fr"),
-        },
-        {
-          value: "ca",
-          label: t("ca"),
-        },
-        {
-          value: "it",
-          label: t("it"),
-        },
-        {
-          value: "uk",
-          label: t("uk"),
-        },
-      ]}
+      items={items}
       label={t("label")}
     />
   );


### PR DESCRIPTION
💡 What: Wrapped the inline `items` array in `LocaleSwitcher` with `useMemo` (dependent on `t`).
🎯 Why: Passing a newly created inline array to a child component on every render forces that child to re-render, as the reference changes.
📊 Impact: Reduces unnecessary re-renders of `LocaleSwitcherSelect`, lowering React reconciliation overhead.
🔬 Measurement: Verify `LocaleSwitcherSelect` no longer re-renders unnecessarily when the parent `NavBar` or `LocaleSwitcher` renders without translation changes.

---
*PR created automatically by Jules for task [2612244982982343592](https://jules.google.com/task/2612244982982343592) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React performance guidelines documentation

* **Refactor**
  * Optimized LocaleSwitcher component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->