### PR TITLE
⚡ Bolt: Transform O(N) photo lookup into O(1) with in-memory cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -106,3 +106,7 @@
 ## 2026-05-07 - [Performance: React Component Redundant Memory Allocations]
 **Learning:** In React components, initializing invariant fallback data structures (like arrays or objects containing `new Date()`) inside the component body forces redundant memory allocation and CPU overhead on every render cycle.
 **Action:** Hoist invariant fallback data structures (e.g., fallback arrays or objects containing `new Date()`) outside the component to the module scope to prevent re-allocation on every render.
+
+## 2026-05-18 - [Performance: Cache Initialization Concurrency]
+**Learning:** When initializing an asynchronous, in-memory cache for stateful services (like `GCSPhotoProvider`), failing to lock the initialization process can cause a race condition where simultaneous concurrent requests trigger redundant initialization cycles (e.g. redundant network calls to fetch metadata).
+**Action:** Include concurrent initialization protection (e.g., storing a `cacheInitPromise`) to prevent race conditions and redundant network calls from simultaneous requests.

--- a/src/services/photos/GCSPhotoProvider.ts
+++ b/src/services/photos/GCSPhotoProvider.ts
@@ -97,6 +97,9 @@ export class GCSPhotoProvider implements PhotoProvider {
   private readonly storage: Storage;
   private readonly bucketName: string;
   private readonly useSignedUrls: boolean;
+  private fileCache: Map<number | string, GCSFile> | null = null;
+  private isCacheInitialized: boolean = false;
+  private cacheInitPromise: Promise<void> | null = null;
 
   constructor(options: GCSPhotoProviderOptions = {}) {
     const {
@@ -184,18 +187,51 @@ export class GCSPhotoProvider implements PhotoProvider {
     }
   }
 
-  async getPhoto(id: string | number): Promise<Photo | null> {
-    try {
+  private async ensureCacheInitialized(): Promise<void> {
+    if (this.isCacheInitialized) return;
+
+    // Concurrent protection
+    if (this.cacheInitPromise) {
+      return this.cacheInitPromise;
+    }
+
+    this.cacheInitPromise = (async () => {
+      /* ⚡ Bolt: Cache file IDs to transform O(N) scans into O(1) lookups */
+      this.fileCache = new Map<number | string, GCSFile>();
       const bucket = this.storage.bucket(this.bucketName);
       const [files] = await bucket.getFiles({ autoPaginate: false });
 
-      const targetId = typeof id === "string" ? Number(id) : id;
-
       for (const file of files) {
         const fileId = extractIdFromFilename(file.name);
-        if (fileId === targetId) {
-          return this.mapFileToPhoto(file);
-        }
+        if (fileId === null) continue;
+
+        this.fileCache.set(fileId, file);
+        this.fileCache.set(String(fileId), file);
+      }
+
+      this.isCacheInitialized = true;
+      this.cacheInitPromise = null;
+
+      // Cache invalidation: we clear the cache after 5 minutes so it doesn't serve stale data indefinitely
+      setTimeout(() => {
+        this.fileCache = null;
+        this.isCacheInitialized = false;
+      }, 5 * 60 * 1000);
+    })();
+
+    return this.cacheInitPromise;
+  }
+
+  async getPhoto(id: string | number): Promise<Photo | null> {
+    try {
+      await this.ensureCacheInitialized();
+
+      const targetId = typeof id === "string" ? Number(id) : id;
+
+      const file = this.fileCache?.get(targetId) || this.fileCache?.get(id);
+
+      if (file) {
+        return this.mapFileToPhoto(file);
       }
 
       return null;


### PR DESCRIPTION
💡 **What:** Implemented an in-memory `fileCache` (Map) within `GCSPhotoProvider.ts` to cache the mapping of photo IDs to `GCSFile` objects. The cache initializes once (protected against concurrent initialization) and invalidates after 5 minutes.
🎯 **Why:** Previously, `getPhoto` fetched the entire list of files from the Google Cloud Storage bucket and iterated through them *every single time* it was called to find a match by ID. This resulted in significant O(N) network latency and CPU overhead, creating a bottleneck for individual photo retrievals.
📊 **Impact:** Reduces network latency and CPU overhead for repeated `getPhoto` calls from O(N) to O(1) by serving subsequent requests directly from memory while still maintaining data freshness via TTL.
🔬 **Measurement:** Verify by running `npm run test src/__tests__/services/photos/GCSPhotoProvider.test.ts` to ensure backward compatibility and observing performance gains on routes invoking `getPhoto` repeatedly.

---
*PR created automatically by Jules for task [12752588227103765190](https://jules.google.com/task/12752588227103765190) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved race conditions during concurrent photo requests with improved initialization handling

* **Performance**
  * Photo lookups now use in-memory caching for significantly faster retrieval
  * Automatic cache expiration after 5 minutes prevents stale data

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anyulled/my-portfolio-website/pull/558)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->