### PR TITLE
⚡ Bolt: Throttle native scroll events to prevent main thread blocking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -110,3 +110,6 @@
 ## 2026-05-18 - [Performance: Cache Initialization Concurrency]
 **Learning:** When initializing an asynchronous, in-memory cache for stateful services (like `GCSPhotoProvider`), failing to lock the initialization process can cause a race condition where simultaneous concurrent requests trigger redundant initialization cycles (e.g. redundant network calls to fetch metadata).
 **Action:** Include concurrent initialization protection (e.g., storing a `cacheInitPromise`) to prevent race conditions and redundant network calls from simultaneous requests.
+## 2026-05-17 - [Performance: Scroll Event Throttling]
+**Learning:** Attaching native DOM `scroll` event listeners that trigger React state updates (e.g., `setIsScrolled`) can overwhelm the main thread, causing frame drops and scroll jank, because `scroll` fires synchronously at a higher frequency than the browser can paint. Adding `{ passive: true }` helps compositor thread scrolling, but does not solve the main thread blocking issue.
+**Action:** Throttle the state updates inside the native scroll event handler using `window.requestAnimationFrame()` and a ticking flag to ensure state updates only occur once per animation frame.

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -60,11 +60,25 @@ export default function NavBar() {
       };
     }
 
+    let ticking = false;
+
     const handleWindowScroll = () => {
-      setIsScrolled(window.scrollY > 50);
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setIsScrolled(window.scrollY > 50);
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
-    window.addEventListener("scroll", handleWindowScroll);
-    handleWindowScroll();
+    /*
+     * ⚡ Bolt: Throttled the native scroll event handler using requestAnimationFrame
+     * to prevent redundant state updates and main thread blocking on rapid scroll events.
+     * Also added { passive: true } to explicitly tell the browser this listener
+     * won't call preventDefault, allowing the compositor thread to scroll immediately.
+     */
+    window.addEventListener("scroll", handleWindowScroll, { passive: true });
+    handleWindowScroll(); // Initial check
     return () => {
       window.removeEventListener("scroll", handleWindowScroll);
     };


### PR DESCRIPTION
💡 What: Throttled the native `scroll` event handler in `NavBar.tsx` using `window.requestAnimationFrame()` and a ticking flag, alongside `{ passive: true }`.

🎯 Why: The `scroll` event fires synchronously at a very high frequency. Without throttling, updating React state (`setIsScrolled`) on every tick forces React to perform redundant calculations and potentially block the main thread, leading to frame drops and scroll jank on lower-end devices. 

📊 Impact: Reduces the frequency of React state update triggers during active scrolling from potentially 100+ times per second down to the monitor's refresh rate (typically 60fps), eliminating main thread congestion.

🔬 Measurement: Profile the scroll performance in Chrome DevTools using CPU throttling. Observe reduced "Scripting" time and fewer dropped frames when scrolling down the page.

---
*PR created automatically by Jules for task [12038506302033489180](https://jules.google.com/task/12038506302033489180) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll performance in the navigation bar by optimizing scroll event handling to reduce jank and deliver smoother scrolling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anyulled/my-portfolio-website/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->