### PR TITLE
⚡ Bolt: O(1) random photo selection on HomePage to prevent redundant allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -113,3 +113,7 @@
 ## 2026-05-17 - [Performance: Scroll Event Throttling]
 **Learning:** Attaching native DOM `scroll` event listeners that trigger React state updates (e.g., `setIsScrolled`) can overwhelm the main thread, causing frame drops and scroll jank, because `scroll` fires synchronously at a higher frequency than the browser can paint. Adding `{ passive: true }` helps compositor thread scrolling, but does not solve the main thread blocking issue.
 **Action:** Throttle the state updates inside the native scroll event handler using `window.requestAnimationFrame()` and a ticking flag to ensure state updates only occur once per animation frame.
+
+## 2026-05-18 - [Performance: Redundant Array Transformations Before Selection]
+**Learning:** Mapping over an entire array (e.g., `heroPhotos.map()`) to format objects, only to immediately select a single random element and discard the rest, causes an $O(N)$ redundant memory allocation and processing overhead on every server render.
+**Action:** Always extract the selection logic (e.g., finding the random index) to pick the specific raw element *first*, and then apply the data transformation/formatting only to that single $O(1)$ element.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,26 +57,29 @@ export default async function HomePage() {
 
   const heroPhotos = heroPhotosRaw || [];
 
-  const formattedHeroImages =
-    heroPhotos.length > 0
-      ? heroPhotos.map((p) => ({
-          image: p.srcSet[0].src,
-          // Default position as GCS doesn't store position data yet
-          position: "center center",
-          alt: p.description || p.title || "Boudoir Session",
-        }))
-      : [
-          {
-            // Fallback if no images found
-            image: "/images/DSC_7028.jpg",
-            position: "left top",
-            alt: "Boudoir Session",
-          },
-        ];
+  /*
+   * ⚡ Bolt: Selected the random photo FIRST, and then formatted only that single photo
+   * into `heroImage`. This prevents mapping over the entire `heroPhotos` array, converting
+   * an O(N) allocation into an O(1) allocation and eliminating redundant object creations
+   * on every server render.
+   */
+  const selectedPhoto = heroPhotos.length > 0
+    ? heroPhotos[Math.floor(Math.random() * heroPhotos.length)]
+    : null;
 
-  // Select a random image on the server to avoid hydration mismatch and improve LCP
-  const heroImage =
-    formattedHeroImages[Math.floor(Math.random() * formattedHeroImages.length)];
+  const heroImage = selectedPhoto
+    ? {
+        image: selectedPhoto.srcSet[0].src,
+        // Default position as GCS doesn't store position data yet
+        position: "center center",
+        alt: selectedPhoto.description || selectedPhoto.title || "Boudoir Session",
+      }
+    : {
+        // Fallback if no images found
+        image: "/images/DSC_7028.jpg",
+        position: "left top",
+        alt: "Boudoir Session",
+      };
 
   return (
     <main>


### PR DESCRIPTION
💡 **What:** Refactored `HomePage` in `src/app/page.tsx` to pick the random photo directly from the raw `heroPhotos` array before formatting it into `heroImage`.

🎯 **Why:** Previously, the code mapped over the *entire* array of fetched photos to construct formatted objects, only to randomly pick one and discard the rest. This caused redundant O(N) object creations and garbage collection overhead on every single server render. 

📊 **Impact:** Reduces redundant memory allocations from $O(N)$ (where $N$ is the limit of fetched hero photos) to $O(1)$. It prevents the creation and immediate discarding of unused JS objects, saving CPU cycles during React Server Component execution.

🔬 **Measurement:** Review the network payload and server memory logs. The tests in `src/__tests__/app/homepage/page.test.tsx` pass, proving identical fallback and rendering logic.

---
*PR created automatically by Jules for task [6764238749763250303](https://jules.google.com/task/6764238749763250303) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Optimized hero image selection logic to select a random photo first and apply transformations only to that single photo, rather than transforming the entire collection before selection. This reduces unnecessary processing and memory allocations during server-side rendering.

* **Documentation**
  * Added performance optimization documentation and best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anyulled/my-portfolio-website/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->