### PR TITLE
⚡ Bolt: Optimize GCS Metadata Fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -148,3 +148,7 @@
 ## 2026-06-25 - [Performance: Next.js/Supabase SSR Cookie deduplication micro-optimization]
 **Learning:** Avoid deduplicating small cookie arrays using a `Map` before calling `cookies().set()` in Next.js/Supabase SSR handlers. This is a counterproductive micro-optimization, as the Map allocation overhead typically exceeds the cost of redundant setter calls.
 **Action:** Do not deduplicate small cookie arrays; allow `cookies().set()` to be called sequentially even if it means some redundant calls.
+## 2026-06-13 - [Performance: GCS Metadata Fetching]
+
+**Learning:** When fetching a limited subset of files from Google Cloud Storage, calling `bucket.getFiles()` without specifying `maxResults` causes the library to fetch the default page size (up to 1000 items) of metadata. This results in significant overhead through large payload parsing, unnecessary network latency, and memory allocation.
+**Action:** Always set `maxResults` to a reasonable buffer (e.g., limit + 20) in the options object passed to `bucket.getFiles` when only a subset of items is needed.

--- a/src/__tests__/services/photos/GCSPhotoProvider.test.ts
+++ b/src/__tests__/services/photos/GCSPhotoProvider.test.ts
@@ -102,6 +102,7 @@ describe("GCSPhotoProvider", () => {
       expect(mockBucketContainer.getFiles).toHaveBeenCalledWith({
         prefix: "styles/boudoir/",
         autoPaginate: false,
+        maxResults: 120, // default limit is 100, buffer is 20
       });
     });
 

--- a/src/services/photos/GCSPhotoProvider.ts
+++ b/src/services/photos/GCSPhotoProvider.ts
@@ -90,11 +90,24 @@ export class GCSPhotoProvider implements PhotoProvider {
 
     try {
       const bucket = this.storage.bucket(this.bucketName);
-      const [files] = await bucket.getFiles({
+
+      const getFilesOptions: any = {
         prefix: opts.prefix,
         autoPaginate: false,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      };
+
+      if (opts.limit && opts.limit > 0) {
+        /*
+         * ⚡ Bolt: Always set maxResults to a reasonable buffer (e.g., limit + 20)
+         * when fetching a subset of files from GCS. This prevents bucket.getFiles()
+         * from loading the default page size (1000 items) of metadata into memory
+         * when only a few items are needed, drastically minimizing payload size,
+         * network latency, and parsing overhead.
+         */
+        getFilesOptions.maxResults = opts.limit + 20;
+      }
+
+      const [files] = await bucket.getFiles(getFilesOptions);
 
       if (!files || files.length === 0) {
         return [];


### PR DESCRIPTION
💡 What: Updated `listPhotos` in `GCSPhotoProvider.ts` to dynamically include `maxResults` in the `getFiles` options when a `limit` is requested (setting it to limit + 20).
🎯 Why: Without `maxResults`, `bucket.getFiles()` defaults to fetching the default page size (up to 1000 items) of metadata into memory even when only a small subset is needed. This optimization prevents unnecessary network latency, memory allocation for parsing metadata, and CPU overhead.
📊 Impact: Drastically minimizes payload size, network latency, and memory footprint when fetching limited subsets of files from Google Cloud Storage.
🔬 Measurement: Verified via unit tests (`GCSPhotoProvider.test.ts`) that the `maxResults` option is correctly passed down to the Google Cloud Storage bucket's `getFiles` method.

---
*PR created automatically by Jules for task [132694888390051021](https://jules.google.com/task/132694888390051021) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo listing efficiency from Google Cloud Storage by fetching only required results plus a buffer, reducing unnecessary payload and network overhead.

* **Tests**
  * Updated photo filtering tests to reflect new fetching behavior.

* **Documentation**
  * Added performance optimization documentation for cloud storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->