### PR TITLE
⚡ Bolt: [performance improvement] Reduce redundant Sharp allocations in resizing cron job

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -134,8 +134,10 @@
 **Action:** Always extract the selection logic (e.g., finding the random index) to pick the specific raw element _first_, and then apply the data transformation/formatting only to that single $O(1)$ element.
 
 ## 2026-05-22 - [Performance: Redundant RegExp Allocations in Batch Processing]
+
 **Learning:** Re-instantiating `RegExp` patterns inside utility functions (like `extractIdFromFilename`) that are called iteratively for every item during batch processing (e.g., scanning thousands of GCS files) causes redundant memory allocations, garbage collection overhead, and degrades CPU performance.
 **Action:** Hoist `RegExp` patterns to the module level to ensure they are created only once and reused across all function calls.
+
 ## 2026-05-23 - [Performance: I/O Operation Concurrency in Cache Writing]
 
 **Learning:** When a service writes data to multiple independent caching layers (e.g., Redis and Vercel Blob), awaiting these operations sequentially creates an unnecessary request waterfall that slows down the overall hydration process.
@@ -145,10 +147,17 @@
 
 **Learning:** Declaring regular expression literals (e.g., `/\.[^/.]+$/`) and static primitive wrapper objects (e.g., `new Date(0)`) inside a function that is called iteratively during a batch process (like mapping thousands of GCS files) forces the JavaScript engine to allocate memory and garbage collect these objects repeatedly, degrading throughput and increasing memory overhead. Additionally, using `.match()` for boolean checks allocates an array of results, while `.test()` only returns a boolean.
 **Action:** Extract invariant RegExp literals and primitive instantiations into module-level constants. When only a boolean check is needed, prefer `RegExp.prototype.test()` over `String.prototype.match()`.
+
 ## 2026-06-25 - [Performance: Next.js/Supabase SSR Cookie deduplication micro-optimization]
+
 **Learning:** Avoid deduplicating small cookie arrays using a `Map` before calling `cookies().set()` in Next.js/Supabase SSR handlers. This is a counterproductive micro-optimization, as the Map allocation overhead typically exceeds the cost of redundant setter calls.
 **Action:** Do not deduplicate small cookie arrays; allow `cookies().set()` to be called sequentially even if it means some redundant calls.
+
 ## 2026-06-13 - [Performance: GCS Metadata Fetching]
 
 **Learning:** When fetching a limited subset of files from Google Cloud Storage, calling `bucket.getFiles()` without specifying `maxResults` causes the library to fetch the default page size (up to 1000 items) of metadata. This results in significant overhead through large payload parsing, unnecessary network latency, and memory allocation.
 **Action:** Always set `maxResults` to a reasonable buffer (e.g., limit + 20) in the options object passed to `bucket.getFiles` when only a subset of items is needed.
+## 2026-06-25 - [Performance: Redundant Sharp Image Parsing]
+
+**Learning:** When generating a buffer from a `sharp` pipeline (e.g., `pipeline.webp().toBuffer()`), calling `sharp(convertedBuffer).metadata()` sequentially afterwards forces an unnecessary second object allocation and re-parses the newly created image buffer, causing CPU and memory overhead.
+**Action:** Use `toBuffer({ resolveWithObject: true })` to return both the generated buffer and its `info` (metadata) in a single pass: `const { data: convertedBuffer, info: newMetadata } = await pipeline.toBuffer({ resolveWithObject: true });`

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -46,7 +46,7 @@ An RFC is a document that proposes a significant change to the project:
 
 ### Drawbacks
 
-[Why should we *not* do this? Consider maintenance, performance, or complexity.]
+[Why should we _not_ do this? Consider maintenance, performance, or complexity.]
 
 ### Alternatives
 

--- a/src/__tests__/app/api/cron/resize-images/route.test.ts
+++ b/src/__tests__/app/api/cron/resize-images/route.test.ts
@@ -25,7 +25,10 @@ jest.mock("sharp", () => {
       .mockResolvedValue({ width: 3000, height: 3000, format: "jpeg" }),
     resize: jest.fn().mockReturnThis(),
     webp: jest.fn().mockReturnThis(),
-    toBuffer: jest.fn().mockResolvedValue(Buffer.alloc(500)),
+    toBuffer: jest.fn().mockResolvedValue({
+      data: Buffer.alloc(500),
+      info: { width: 3000, height: 3000, format: "webp" }
+    }),
   };
   return jest.fn(() => mockSharpInstance);
 });

--- a/src/app/api/cron/resize-images/route.ts
+++ b/src/app/api/cron/resize-images/route.ts
@@ -50,10 +50,7 @@ interface ProcessResult {
 }
 
 function isValidImage(file: GCSFile): boolean {
-  return (
-    !file.name.endsWith("/") &&
-    VALID_IMAGE_PATTERN.test(file.name)
-  );
+  return !file.name.endsWith("/") && VALID_IMAGE_PATTERN.test(file.name);
 }
 
 // eslint-disable-next-line complexity
@@ -137,9 +134,15 @@ async function processImage(
         })
       : image;
 
-    const convertedBuffer = await pipeline.webp({ quality: 80 }).toBuffer();
+    /*
+     * ⚡ Bolt: Removed redundant `sharp(convertedBuffer).metadata()` call.
+     * By using `resolveWithObject: true`, we get both the buffer and metadata
+     * in a single pass, saving CPU and memory overhead.
+     */
+    const { data: convertedBuffer, info: newMetadata } = await pipeline
+      .webp({ quality: 80 })
+      .toBuffer({ resolveWithObject: true });
     const newBytes = convertedBuffer.length;
-    const newMetadata = await sharp(convertedBuffer).metadata();
 
     const newFile = bucket.file(newFileName);
     // Prepare metadata, filtering out 'name' to avoid conflicts

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -22,7 +22,10 @@ const createDbClient = (cookies: ReadonlyRequestCookies) =>
              * ⚡ Bolt: Deduplicate cookie updates by name to prevent redundant internal
              * state re-evaluations and minimize synchronous overhead from `cookies.set()`.
              */
-            const uniqueCookies = new Map<string, { name: string; value: string; options: CookieOptions }>();
+            const uniqueCookies = new Map<
+              string,
+              { name: string; value: string; options: CookieOptions }
+            >();
             for (const c of cookie) {
               uniqueCookies.set(c.name, c);
             }


### PR DESCRIPTION
💡 **What:** Replaced the sequential calls to `pipeline.toBuffer()` and `sharp(buffer).metadata()` with a single `pipeline.toBuffer({ resolveWithObject: true })` call in the image resizing cron job (`src/app/api/cron/resize-images/route.ts`).
🎯 **Why:** Creating a new buffer and then immediately feeding it back into a new `sharp` instance to extract its metadata forces the library to allocate a second pipeline and re-parse the image data.
📊 **Impact:** Reduces CPU overhead and memory allocation spikes in the high-volume cron job by retrieving both the compressed image buffer and its metadata (e.g. width and height) in a single pass.
🔬 **Measurement:** Verify by ensuring the `getFilesStream` cron job continues to properly capture resized image dimensions and save them to metadata without errors, and that all test cases pass.

---
*PR created automatically by Jules for task [4161158027323516072](https://jules.google.com/task/4161158027323516072) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved image processing efficiency by generating WebP image data and metadata together, reducing redundant processing.
  - Added performance guidance for image handling and server-side cookie processing.

- **Documentation**
  - Updated the RFC template’s emphasis formatting for improved consistency.

- **Tests**
  - Updated image-resizing test coverage to reflect the enhanced image-processing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->