### PR TITLE
⚡ Bolt: [performance improvement] Optimize array iteration in opengraph-image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -161,3 +161,7 @@
 
 **Learning:** When generating a buffer from a `sharp` pipeline (e.g., `pipeline.webp().toBuffer()`), calling `sharp(convertedBuffer).metadata()` sequentially afterwards forces an unnecessary second object allocation and re-parses the newly created image buffer, causing CPU and memory overhead.
 **Action:** Use `toBuffer({ resolveWithObject: true })` to return both the generated buffer and its `info` (metadata) in a single pass: `const { data: convertedBuffer, info: newMetadata } = await pipeline.toBuffer({ resolveWithObject: true });`
+
+## 2024-05-18 - Early Exit in OpenGraph Image Generation
+**Learning:** Chained array methods (`.map().filter().slice()`) process the entire array even when only a few items are needed, causing O(N) overhead.
+**Action:** Replace chained array methods with a `for...of` loop and early exit (`break`) when extracting a limited subset of items to achieve O(limit) time complexity.

--- a/src/app/pricing/opengraph-image.tsx
+++ b/src/app/pricing/opengraph-image.tsx
@@ -52,13 +52,18 @@ export default async function PricingImage() {
     }
 
     /*
-     * Take up to 3 images - use remote URLs directly instead of encoding
-     * Satori doesn't support WebP, so filter to only JPEG/PNG
+     * ⚡ Bolt: Replaced chained .map(), .filter(), and .slice() with a single
+     * for...of loop. This extracts up to 3 valid non-WebP image URLs in one pass,
+     * avoiding redundant intermediate array allocations and O(N) iteration overhead.
      */
-    const imageUrls = photos
-      .map((p) => p.srcSet[0]?.src)
-      .filter((url): url is string => Boolean(url) && !url.endsWith(".webp"))
-      .slice(0, 3);
+    const imageUrls: string[] = [];
+    for (const photo of photos) {
+      if (imageUrls.length >= 3) break;
+      const url = photo.srcSet[0]?.src;
+      if (url && !url.endsWith(".webp")) {
+        imageUrls.push(url);
+      }
+    }
 
     if (imageUrls.length === 0) {
       console.warn("[PricingOG] No valid non-WebP image URLs, using fallback.");


### PR DESCRIPTION
💡 What: Replaced chained `.map().filter().slice(0, 3)` with a single `for...of` loop with an early exit in `src/app/pricing/opengraph-image.tsx`.
🎯 Why: Chained methods iterate over the entire array multiple times and allocate intermediate arrays. Using a `for...of` loop allows us to exit early as soon as we find the 3 valid image URLs needed.
📊 Impact: Reduces array allocations and changes the time complexity from O(N) to O(3) worst-case processing for valid image extraction.
🔬 Measurement: Run the test suite and verify `src/app/pricing/opengraph-image.tsx` handles images efficiently without allocating intermediate arrays for unneeded images.

---
*PR created automatically by Jules for task [11342631384960360350](https://jules.google.com/task/11342631384960360350) started by @anyulled*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Open Graph image generation efficiency when selecting fallback photos.
  * Preserved existing fallback behavior and image output.
* **Documentation**
  * Added guidance documenting the optimized approach for limiting image selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->